### PR TITLE
fix: wrong input

### DIFF
--- a/ship.yml
+++ b/ship.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Publish module
         run: |
           deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts link ${{ secrets.NESTAPIKEY }}
-          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts publish --version ${{ github.event.inputs.tags }}
+          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts publish --version ${{ github.event.inputs.version }}


### PR DESCRIPTION
the input from `workflow_dispatch` event has the id `version` but the publish command used the id `tags`

cc @oganexon 