### PR TITLE
Publish

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -6,40 +6,10 @@ GitHub Actions Workflow template for automatically publishing packages with Eggs
 
 This repo has three workflows: Lint, Test and Ship
 
-#### Lint
+- **Lint** - runs `deno lint` and `deno fmt` on your repository
 
-This workflow lists your deno code and checks if it is properly formatted.
+- **Test** - run all the available tests in your repository
 
-#### Test
+- **Ship** - publish your module to nest.land whenever you create a release or push a tag to your GitHub repository
 
-This workflow will run all the available tests in your repo.
-
-#### Ship
-
-This workflow will publish your module to nest.land on demand
-
-this workflow needs your nest.land API key to be passed in as a secret.
-
-follow these steps to create a new secret:
-
-1. Go to your repository settings
-2. Go to the "Secrets" menu
-3. Click the "new secret" button
-4. Set the name to `NESTAPIKEY`
-5. Set the value to your nest.land API key
-6. Click the "add secret" button
-
-![image for step 1, 2 and 3](https://user-images.githubusercontent.com/28438021/88387051-4eab6080-cdcf-11ea-9848-4aab55825e4c.png)
-
-![image for step 4, 5 and 6](https://user-images.githubusercontent.com/28438021/88387746-c4fc9280-cdd0-11ea-9cdf-2eb3ea05af32.png)
-
-Now when you are ready you can follow these steps to publish your module
-
-1. Go to the "Actions" tab of your repository
-2. Select the "Ship" workflow
-3. Select the "Run workflow" dropdown
-4. Select the branch that has your module code.
-5. Enter the version (to be published)
-6. Click the "run workflow" button
-
-![image for step 1, 2, 3, 4, 5 and 6](https://user-images.githubusercontent.com/28438021/88389691-95e82000-cdd4-11ea-92a9-b55a0d3a4cf9.png)
+> **NOTE:** You need to set your nest.land api key as a secret for the "Ship" workflow to run. See [GitHub Secrets docs](https://docs.github.com/actions/reference/encrypted-secrets) for more details.

--- a/.github/README.md
+++ b/.github/README.md
@@ -12,4 +12,4 @@ This repo has three workflows: Lint, Test and Ship
 
 - **Ship** - publish your module to nest.land whenever you create a release or push a tag to your GitHub repository
 
-> **NOTE:** You need to set your nest.land api key as a secret for the "Ship" workflow to run. See [GitHub Secrets docs](https://docs.github.com/actions/reference/encrypted-secrets) for more details.
+> **NOTE:** You need to set your nest.land api key as a secret named `NESTAPIKEY` for the "Ship" workflow to run. See [GitHub Secrets docs](https://docs.github.com/actions/reference/encrypted-secrets) for more details.

--- a/ship.yml
+++ b/ship.yml
@@ -1,12 +1,8 @@
 name: Ship
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Version"
-        required: true
-
+  create:
+    ref_type: "tag"
 
 jobs:
   release:
@@ -17,8 +13,11 @@ jobs:
 
       - name: Setup Deno
         uses: denolib/setup-deno@v2
+        with:
+          deno-version: v1.5.x
 
       - name: Publish module
         run: |
-          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts link ${{ secrets.NESTAPIKEY }}
-          deno run -A --unstable https://x.nest.land/eggs@0.2.1/mod.ts publish --version ${{ github.event.inputs.version }}
+          deno install -A --unstable https://x.nest.land/eggs@0.3.2/eggs.ts
+          eggs link ${{ secrets.NESTAPIKEY }}
+          eggs publish --yes --no-check --version $(git describe --tags $(git rev-list --tags --max-count=1))


### PR DESCRIPTION
Earlier you had to manually run the workflow to publish to nest.land. With the new workflow you can publish by creating a release or pushing a new tag.

This PR also removes the instructions for the manual trigger.

---
for future reference:

#### tl;dr for creating the github secret

1. Go to your repository settings
2. Go to the "Secrets" menu
3. Click the "new secret" button
4. Set the name to `NESTAPIKEY`
5. Set the value to your nest.land API key
6. Click the "add secret" button

![image for step 1, 2 and 3](https://user-images.githubusercontent.com/28438021/88387051-4eab6080-cdcf-11ea-9848-4aab55825e4c.png)

![image for step 4, 5 and 6](https://user-images.githubusercontent.com/28438021/88387746-c4fc9280-cdd0-11ea-9cdf-2eb3ea05af32.png)
